### PR TITLE
Update Tautulli docker image to build from python:3.13.1

### DIFF
--- a/Docker/Tautulli/Dockerfile
+++ b/Docker/Tautulli/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 AS builder
+FROM python:3.13.1 AS builder
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Try to fix missing `regex` package that comes from pip install requirements.txt